### PR TITLE
Update hamcrest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,7 @@
     <httpclient.version>4.5.12</httpclient.version>
     <unirest.version>1.4.9</unirest.version>
     <jackson.version>2.10.0.pr3</jackson.version>
-    <hamcrest.version>2.2</hamcrest.version>
     <jackson.version>2.10.0.pr3</jackson.version>
-	<!--<hamcrest.version>1.3</hamcrest.version>-->
     <workflow-api.version>2.22</workflow-api.version>
     <workflow-support.version>2.14</workflow-support.version>
     <!-- testing libs -->
@@ -219,8 +217,8 @@
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <httpclient.version>4.5.12</httpclient.version>
     <unirest.version>1.4.9</unirest.version>
     <jackson.version>2.10.0.pr3</jackson.version>
+    <hamcrest.version>2.2</hamcrest.version>
     <jackson.version>2.10.0.pr3</jackson.version>
     <workflow-api.version>2.22</workflow-api.version>
     <workflow-support.version>2.14</workflow-support.version>
@@ -283,18 +284,6 @@
       <artifactId>workflow-support</artifactId>
       <version>${workflow-support.version}</version>
       <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>${hamcrest.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-library</artifactId>
-      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
_🤖 This is an automatic PR for replacing the deprecated 'hamcrest-*' modules with 'hamcrest'._

  All deprecated modules' code has been merged into 'hamcrest'.
  Consumers of `hamcrest-*` should replace the dependency with `hamcrest`, which is the drop-in module containing the code of the deprecated `hamcrest-*` modules.

  Ping `@NotMyFault` if you have questions.

  _[script source](https://github.com/NotMyFault/jenkins-version-updater)_