### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 // Builds a module using https://github.com/jenkins-infra/pipeline-library
 def configurations = [
         [ platform: "linux", jdk: "8", jenkins: null ],
-        //[ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ]
+        //[ platform: "linux", jdk: "11", jenkins: null ]
 ]
 buildPlugin(configurations: configurations, useContainerAgent: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,4 +3,4 @@ def configurations = [
         [ platform: "linux", jdk: "8", jenkins: null ],
         //[ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ]
 ]
-buildPlugin(configurations: configurations, useAci: true)
+buildPlugin(configurations: configurations, useContainerAgent: true)


### PR DESCRIPTION
The useAci option is deprecated in favor of useContainerAgent.
This PR updates the deprecated reference.

I'll expedite the merge, once the infrastructure changes to ci.jenkins.io have been merged into production, to prevent failing builds on the default branch and new pull requests.